### PR TITLE
support version 13 of tap

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -1,6 +1,9 @@
 name: test-summary
 description: Generates a GitHub Actions Job Summary from various unit testing reports
 inputs:
+  title:
+    required: false
+    description: title for test results in summary
   tap-paths:
     description: glob matching TAP files
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -4335,6 +4335,8 @@ class Summary {
 _Summary_buffer = new WeakMap();
 const summary = new Summary();
 async function main() {
+    let version = 12;
+    const title = core.getInput('title');
     const tapPaths = core.getInput('tap-paths');
     // MSED - consider using @actions/glob to convert tapPaths wildcards to useful information
     const tapData = await fs.readFile(tapPaths, { encoding: 'utf8' });
@@ -4344,7 +4346,10 @@ async function main() {
         switch (tapEvent[0]) {
             case 'complete':
                 ok = tapEvent[1].ok;
-                summary.addHeading(`${tapEvent[1].count} run, ${tapEvent[1].skip} skipped, ${tapEvent[1].fail} failed.`);
+                summary.addHeading(`${title ? `${title}: ` : ''}${tapEvent[1].count} run, ${tapEvent[1].skip} skipped, ${tapEvent[1].fail} failed.`);
+                break;
+            case 'version':
+                version = tapEvent[1];
                 break;
             default:
                 break;
@@ -4355,17 +4360,26 @@ async function main() {
         switch (tapEvent[0]) {
             case 'assert':
                 let extra = '';
-                while (tapEvents[i + 1][0] === 'extra' || tapEvents[i + 1][0] === 'comment') {
-                    extra += stripPrefixes(String(tapEvents[i + 1][1]).trim()) + '\n';
-                    ++i;
+                if (version === 12) {
+                    while (tapEvents[i + 1][0] === 'extra' || tapEvents[i + 1][0] === 'comment') {
+                        extra += stripPrefixes(String(tapEvents[i + 1][1]).trim()) + '\n';
+                        ++i;
+                    }
                 }
                 if (!tapEvent[1].ok) {
                     summary.addHeading(`❌ ${stripPrefixes(tapEvent[1].name)}`, 4);
+                    if (version === 13) {
+                        for (const err of tapEvent[1].diag?.errors ?? []) {
+                            if (err.errMsg)
+                                extra += stripPrefixes(err.errMsg.trim()) + '\n';
+                        }
+                    }
                     if (extra) {
                         summary.addCodeBlock(removeLeadingWhitespace(extra).trim());
                     }
                 }
                 break;
+            case 'version':
             case 'extra':
             case 'comment':
             case 'plan':

--- a/lib/tap-parser.d.ts
+++ b/lib/tap-parser.d.ts
@@ -1,11 +1,20 @@
 declare module 'tap-parser' {
+  type Diagnosis = {
+    errors?: {
+      errMsg?: string
+    }[]
+    severity: string
+  }
+
   type Result = {
     ok: boolean
     id: number
     name: string
     fullname: string
+    diag?: Diagnosis
   }
 
+  type Version = ['version', number]
   type Assert = ['assert', Result]
   type Extra = ['extra', string]
   type Comment = ['comment', string]
@@ -32,7 +41,7 @@ declare module 'tap-parser' {
     },
   ]
 
-  type Events = Assert | Comment | Extra | Plan | Complete
+  type Events = Version | Assert | Comment | Extra | Plan | Complete
 
   class Parser {
     static parse(data: string): Events[]


### PR DESCRIPTION
This extends the parsing functionality of test-summary to support basic version 13 error reporting. It also adds an optional title input field to differentiate multiple tap file parsings:
![Screenshot 2023-01-03 at 8 50 19 AM](https://user-images.githubusercontent.com/1205450/210422242-52e91c96-6dd9-4ecc-87c5-32607f3ed35c.png)
![Screenshot 2023-01-03 at 8 52 06 AM](https://user-images.githubusercontent.com/1205450/210422396-67c42c75-29bf-4f55-ad57-69d73317ba77.png)
